### PR TITLE
Fix #39 position should not be fixed when ancestor is

### DIFF
--- a/jquery.imgareaselect.dev.js
+++ b/jquery.imgareaselect.dev.js
@@ -1093,9 +1093,6 @@ $.imgAreaSelect = function (img, options) {
     while ($p.length) {
         zIndex = max(zIndex,
             !isNaN($p.css('z-index')) ? $p.css('z-index') : zIndex);
-        /* Also check if any of the ancestor elements has fixed position */ 
-        if ($p.css('position') == 'fixed')
-            position = 'fixed';
 
         $p = $p.parent(':not(body)');
     }


### PR DESCRIPTION
As noted in #39, these two lines cause imgAreaSelect to be misplaced in fixed elements like modals. Removing them fixes the problem.
