### PR TITLE
Fix grab image handles on mobile devices

### DIFF
--- a/jquery.imgareaselect.js
+++ b/jquery.imgareaselect.js
@@ -553,8 +553,8 @@ $.imgAreaSelect = function (img, options) {
              */
             checkResize(event);
         }
-        else
-            adjust();
+
+        adjust();
 
         if (resize) {
             /* Resize mode is in effect */


### PR DESCRIPTION
Calling the adjust function fixes the issue on mobile devices when trying to grab the upper left or lower left resize handle.
