### PR TITLE
Allow aspectRatio to be passed as a float

### DIFF
--- a/jquery.imgareaselect.dev.js
+++ b/jquery.imgareaselect.dev.js
@@ -983,7 +983,11 @@ $.imgAreaSelect = function (img, options) {
         }
 
         /* Calculate the aspect ratio factor */
-        aspectRatio = (d = (options.aspectRatio || '').split(/:/))[0] / d[1];
+        if ($.type(options.aspectRatio) === "string" && options.aspectRatio.indexOf(':') > -1) {
+            aspectRatio = (d = (options.aspectRatio || '').split(/:/))[0] / d[1];
+        } else {
+            aspectRatio = parseFloat(options.aspectRatio);
+        }
 
         $img.add($outer).unbind('mousedown', imgMouseDown);
         


### PR DESCRIPTION
Currently, aspect ratio must be supplied as two numbers separated by a colon.

``` js
options = {
    aspectRatio: "4:3"
}
```

However, it is often useful to provide the aspect ratio as a single number. 
Especially if the aspect ratio is calculated by code.

This patch allows configurations such as:

``` js
options = {
    aspectRatio: 1.5
}
```
